### PR TITLE
fix: #3 lock body scroll for open header based on CSS has selector

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,6 +57,10 @@ html {
   scroll-behavior: smooth;
 }
 
+body:has(header#header.is-open){
+  overflow: hidden;
+}
+
 @media screen and (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;


### PR DESCRIPTION
Closes #3

Fix page body scroll when mobile menu is open and trying to scroll the menu content, easy fix by modern CSS approach.

```css
body:has(header#header.is-open){
  overflow: hidden;
};
```